### PR TITLE
Parse pid because it's string (object's key).

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function killAll (tree, signal) {
             }
         });
         if (!killed[pid]) {
-            killPid(pid, signal);
+            killPid(parseInt(pid, 10), signal);
             killed[pid] = 1;
         }
     });


### PR DESCRIPTION
Getting error that pid must be a number in unstable Node.js.