### PR TITLE
Bump version number to a 1.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-kill",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "kill trees of processes",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Any reason why not to? Again, look at the stats:
1,278 downloads in the last day
24,134 downloads in the last week
84,486 downloads in the last month

Dependents
phearjs, pum, daemonspawn, xgulp, prerender, project-nexus, lovelock, nodefm-rpi, node-muse, readit-md, grunt-longrunning, docker-stream, nrepl-client, matt-daemon, grunt-servers, grunt-java-server

I would argue that with this much usage, and so few bug reports, that tree-kill basically works and (now that we support node-backs) the API is stable. I can't think of anything to add at this point except better support for niche platforms.