### PR TITLE
Add callback-as-second-argument support to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,11 +5,8 @@
  * @param signal 'SIGTERM' by default
  * @param callback
  */
-declare function treeKill(
-    pid: number,
-    signal?: string | number,
-    callback?: (error?: Error) => void,
-): void;
+declare function treeKill(pid: number, callback?: (error?: Error) => void): void;
+declare function treeKill(pid: number, signal?: string | number, callback?: (error?: Error) => void): void;
 
 declare namespace treeKill {}
 


### PR DESCRIPTION
To work around this problem:

<img width="591" alt="screenshot 2018-11-03 at 17 28 53" src="https://user-images.githubusercontent.com/189580/47954739-0b231a00-df8e-11e8-8e7b-7434fd399c31.png">
