### PR TITLE
fix: sanitise pid parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ var spawn = childProcess.spawn;
 var exec = childProcess.exec;
 
 module.exports = function (pid, signal, callback) {
+    if (typeof pid !== "number") {
+        throw new Error("pid must be a number");
+    }
+
     var tree = {};
     var pidsToProcess = {};
     tree[pid] = [];


### PR DESCRIPTION
This patch adds a simple check to the process ID passed in, ensuring it is a number, and throwing an error otherwise. The aim is to fix the issue explained here:

- https://hackerone.com/reports/701183
- https://snyk.io/vuln/SNYK-JS-TREEKILL-536781

Fixes: #30