### PR TITLE
Kill tree in reverse order to kill main process in last

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (pid, signal, callback) {
 function killAll (tree, signal, callback) {
     var killed = {};
     try {
-        Object.keys(tree).forEach(function (pid) {
+        Object.keys(tree).reverse().forEach(function (pid) {
             tree[pid].forEach(function (pidpid) {
                 if (!killed[pidpid]) {
                     killPid(pidpid, signal);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-kill",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "kill trees of processes",
   "main": "index.js",
   "types": "index.d.ts",
@@ -8,7 +8,7 @@
     "tree-kill": "cli.js"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha test/test.js"
   },
   "repository": {
     "type": "git",

--- a/test/split_and_spin.js
+++ b/test/split_and_spin.js
@@ -1,0 +1,6 @@
+var fork = require('child_process').fork;
+fork('./test/spin')
+fork('./test/spin')
+setInterval(function(){
+	// Do nothing
+}, 100);

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var fork = require('child_process').fork;
 var kill = require('..');
+const { spawnSync } = require('child_process');
 
 describe('kill()', function(){
     it('should kill a process', function(done){ 
@@ -33,9 +34,6 @@ describe('kill()', function(){
     })
 
     it('should reject invalid pid', function(done){
-        var p = fork('./test/spin')
-        assert.ok(p.pid)
-
         kill('rm -rf /dev/null', function(err) {
             assert.ok(typeof err === 'object')
             return done()
@@ -43,9 +41,6 @@ describe('kill()', function(){
     })
 
     it('should reject invalid pids even if no callback', function(done){
-        var p = fork('./test/spin')
-        assert.ok(p.pid)
-
         try {
             kill('rm -rf /dev/null')
             assert.fail('should have thrown')
@@ -53,5 +48,16 @@ describe('kill()', function(){
             assert.ok(typeof err === 'object')
             return done();
         }
+    })
+
+    it('should self kill even if multiple sub-branches of processes', function(done){ 
+        var p = fork('./test/split_and_spin')
+        assert.ok(p.pid)
+
+        p.on('exit', function(code, signal){
+            assert.ok(code || signal, 'should return an exit code')
+            return done()
+        });
+        setTimeout(() => kill(p.pid), 100)
     })
 })


### PR DESCRIPTION
Resolve #45 

Fix 2 tests were uneeded fork were made, resulting in lost processes
Travel the tree in reverse order to kill main process in last, as described in #45

# How to test
1. See #45 for complete e2e test
2. Start unit tests with `npm run test`